### PR TITLE
auth state consistency

### DIFF
--- a/jupyterhub/jupyterhub/overlays/ldap/jupyterhub-dc.yaml
+++ b/jupyterhub/jupyterhub/overlays/ldap/jupyterhub-dc.yaml
@@ -81,6 +81,14 @@
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value: 
+    name: JUPYTERHUB_CRYPT_KEY
+    valueFrom:
+      secretKeyRef:
+        name: $(jupyterhub_internal_secret)
+        key: JUPYTERHUB_CRYPT_KEY
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value: 
     name: LDAP_SECRET_MOUNT
     valueFrom:
       configMapKeyRef:

--- a/jupyterhub/jupyterhub/overlays/ldap/jupyterhub-internal-sample-secret.yaml
+++ b/jupyterhub/jupyterhub/overlays/ldap/jupyterhub-internal-sample-secret.yaml
@@ -6,3 +6,4 @@ metadata:
 stringData:
   CONFIGPROXY_AUTH_TOKEN: ""
   JPY_COOKIE_SECRET: ""
+  JUPYTERHUB_CRYPT_KEY: ""


### PR DESCRIPTION
When the Hub pod is restarted auth state is defacto cleared because it can no longer be decrypted.

This is because we are omitting the environment variable that makes the auth state keys persistent, without this they are automatically being rotated. Also added this entry to the sample secret.